### PR TITLE
增加redis接口限流注解

### DIFF
--- a/blog-springboot/src/main/java/com/minzheng/blog/annotation/AccessLimit.java
+++ b/blog-springboot/src/main/java/com/minzheng/blog/annotation/AccessLimit.java
@@ -1,0 +1,24 @@
+package com.minzheng.blog.annotation;
+
+import java.lang.annotation.*;
+
+/**
+ * @author hnz
+ * @date 2022/3/23 11:16
+ * @description redis接口限流
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface AccessLimit {
+
+    /**
+     * @return 单位时间（秒）
+     */
+    int seconds();
+
+    /**
+     * @return 单位时间最大请求次数
+     */
+    int maxCount();
+}

--- a/blog-springboot/src/main/java/com/minzheng/blog/config/WebMvcConfig.java
+++ b/blog-springboot/src/main/java/com/minzheng/blog/config/WebMvcConfig.java
@@ -2,6 +2,8 @@ package com.minzheng.blog.config;
 
 
 import com.minzheng.blog.handler.PageableHandlerInterceptor;
+import com.minzheng.blog.handler.WebSecurityHandler;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
@@ -16,6 +18,11 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @Configuration
 public class WebMvcConfig implements WebMvcConfigurer {
 
+    @Bean
+    public WebSecurityHandler getWebSecurityHandler() {
+        return new WebSecurityHandler();
+    }
+
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
@@ -28,6 +35,7 @@ public class WebMvcConfig implements WebMvcConfigurer {
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(new PageableHandlerInterceptor());
+        registry.addInterceptor(getWebSecurityHandler());
     }
 
 

--- a/blog-springboot/src/main/java/com/minzheng/blog/controller/UserAuthController.java
+++ b/blog-springboot/src/main/java/com/minzheng/blog/controller/UserAuthController.java
@@ -1,6 +1,7 @@
 package com.minzheng.blog.controller;
 
 
+import com.minzheng.blog.annotation.AccessLimit;
 import com.minzheng.blog.dto.UserAreaDTO;
 import com.minzheng.blog.dto.UserInfoDTO;
 import com.minzheng.blog.vo.PageResult;
@@ -34,6 +35,7 @@ public class UserAuthController {
      * @param username 用户名
      * @return {@link Result<>}
      */
+    @AccessLimit(seconds = 60, maxCount = 1)
     @ApiOperation(value = "发送邮箱验证码")
     @ApiImplicitParam(name = "username", value = "用户名", required = true, dataType = "String")
     @GetMapping("/users/code")

--- a/blog-springboot/src/main/java/com/minzheng/blog/handler/WebSecurityHandler.java
+++ b/blog-springboot/src/main/java/com/minzheng/blog/handler/WebSecurityHandler.java
@@ -1,0 +1,68 @@
+package com.minzheng.blog.handler;
+
+import com.alibaba.fastjson.JSON;
+import com.minzheng.blog.annotation.AccessLimit;
+import com.minzheng.blog.service.RedisService;
+import com.minzheng.blog.util.IpUtils;
+import com.minzheng.blog.vo.Result;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.RedisConnectionFailureException;
+import org.springframework.stereotype.Component;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.OutputStream;
+
+/**
+ * @author hnz
+ * @date 2022/3/23 11:21
+ * @description
+ */
+@Log4j2
+public class WebSecurityHandler implements HandlerInterceptor {
+    @Autowired
+    private RedisService redisService;
+
+    @Override
+    public boolean preHandle(HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse, Object handler) throws Exception {
+        //如果请求输入方法
+        if (handler instanceof HandlerMethod) {
+            HandlerMethod hm = (HandlerMethod) handler;
+            //获取方法中的注解,看是否有该注解
+            AccessLimit accessLimit = hm.getMethodAnnotation(AccessLimit.class);
+            if (accessLimit != null) {
+                long seconds = accessLimit.seconds();
+                int maxCount = accessLimit.maxCount();
+                //关于key的生成规则可以自己定义 本项目需求是对每个方法都加上限流功能，如果你只是针对ip地址限流，那么key只需要只用ip就好
+                String key = IpUtils.getIpAddress(httpServletRequest) + hm.getMethod().getName();
+                //从redis中获取用户访问的次数
+                try {
+                    //此操作代表获取该key对应的值自增1后的结果
+                    long q = redisService.incrExpire(key, seconds);
+                    if (q > maxCount) {
+                        render(httpServletResponse, Result.ok(null, "请求过于频繁，请稍候再试"));
+                        log.warn(key + "请求次数超过每" + seconds + "秒" + maxCount + "次");
+                        return false;
+                    }
+                    return true;
+                } catch (RedisConnectionFailureException e) {
+                    log.warn("redis错误: " + e.getMessage());
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private void render(HttpServletResponse response, Result<?> result) throws Exception {
+        response.setContentType("application/json;charset=UTF-8");
+        OutputStream out = response.getOutputStream();
+        String str = JSON.toJSONString(result);
+        out.write(str.getBytes("UTF-8"));
+        out.flush();
+        out.close();
+    }
+}

--- a/blog-springboot/src/main/java/com/minzheng/blog/service/RedisService.java
+++ b/blog-springboot/src/main/java/com/minzheng/blog/service/RedisService.java
@@ -95,6 +95,15 @@ public interface RedisService {
     Long incr(String key, long delta);
 
     /**
+     * 获取自增1后的 值
+     *
+     * @param key  key值
+     * @param time 过期时间
+     * @return 返回递增后结果
+     */
+    Long incrExpire(String key, long time);
+
+    /**
      * 按delta递减
      *
      * @param key   key值

--- a/blog-springboot/src/main/java/com/minzheng/blog/service/impl/RedisServiceImpl.java
+++ b/blog-springboot/src/main/java/com/minzheng/blog/service/impl/RedisServiceImpl.java
@@ -80,6 +80,15 @@ public class RedisServiceImpl implements RedisService {
     }
 
     @Override
+    public Long incrExpire(String key, long time) {
+        Long count = redisTemplate.opsForValue().increment(key, 1);
+        if (count != null && count == 1) {
+            redisTemplate.expire(key, time, TimeUnit.SECONDS);
+        }
+        return count;
+    }
+
+    @Override
     public Long decr(String key, long delta) {
         return redisTemplate.opsForValue().increment(key, -delta);
     }


### PR DESCRIPTION
增加redis接口限流注解
1.通用限流注解，使用【ip:方法名】作为redis主键
2.可自定义单位时间内接口请求最大次数
3.目前对发送邮箱验证码接口进行了限流，有其他接口需求可以自行加上注解